### PR TITLE
Configure Cloudfront/S3 Caching Behavior

### DIFF
--- a/master_deploy.sh
+++ b/master_deploy.sh
@@ -649,12 +649,12 @@ deploy_s3bucket() {
 	cat /etc/mime.types  | grep -i map
 	cat /etc/mime.types  | grep -i ttf
 	if [ "$CFCACHE" = "true" ]; then
-        # caching is enabled, so set the cache control's max age
-        S3_CACHE_OPTIONS="--cache-control max-age=0,s-maxage=86400"     
+		# caching is enabled, so set the cache control's max age
+		S3_CACHE_OPTIONS="--cache-control max-age=0,s-maxage=86400"     
 		echo "*** Deploying with Cloudfront Cache enabled ***"  
 	else
-        # caching is disabled, so set the cache control to never cache
-     	S3_CACHE_OPTIONS="--cache-control private,no-store,no-cache,must-revalidate,max-age=0"
+		# caching is disabled, so set the cache control to never cache
+		S3_CACHE_OPTIONS="--cache-control private,no-store,no-cache,must-revalidate,max-age=0"
 		echo "*** Deploying with Cloudfront Cache disabled ***"  
 	fi
 

--- a/master_deploy.sh
+++ b/master_deploy.sh
@@ -724,7 +724,7 @@ check_invalidation_status() {
 
 invalidate_cf_cache()
 {
-    if [ "$CFCACHE" = "true" ]; then
+    #if [ "$CFCACHE" = "true" ]; then
          if [ -z $AWS_CLOUD_FRONT_ID ]; then
             echo "Based on header applicaiton has invalidated"
             echo "Skipped which is based on AWS cloudfront ID.Kindly raise request to configure cloud front ID in deployment configuration"
@@ -733,7 +733,7 @@ invalidate_cf_cache()
             INVALIDATE_ID=`aws cloudfront create-invalidation --distribution-id $AWS_CLOUD_FRONT_ID --paths '/*' | $JQ '.Invalidation.Id'`
             check_invalidation_status "$INVALIDATE_ID"
          fi
-    fi
+    #fi
 }
 
 download_envfile()

--- a/master_deploy.sh
+++ b/master_deploy.sh
@@ -649,10 +649,13 @@ deploy_s3bucket() {
 	cat /etc/mime.types  | grep -i map
 	cat /etc/mime.types  | grep -i ttf
 	if [ "$CFCACHE" = "true" ]; then
- 		S3_CACHE_OPTIONS="--cache-control private,no-store,no-cache,must-revalidate,max-age=0"
-		echo "*** Deploying with Cloudfront Cache disabled ***"       
+        # caching is enabled, so set the cache control's max age
+        S3_CACHE_OPTIONS="--cache-control max-age=0,s-maxage=86400"     
+		echo "*** Deploying with Cloudfront Cache enabled ***"  
 	else
-        S3_CACHE_OPTIONS="--cache-control max-age=0,s-maxage=86400"
+        # caching is disabled, so set the cache control to never cache
+     	S3_CACHE_OPTIONS="--cache-control private,no-store,no-cache,must-revalidate,max-age=0"
+		echo "*** Deploying with Cloudfront Cache disabled ***"  
 	fi
 
 	S3_OPTIONS="--exclude '*.txt' --exclude '*.js' --exclude '*.css'"


### PR DESCRIPTION
This PR sets the cache behavior as follows, which is how I would expect it work given the naming conventions.

If the app enables caching:

- `ENABLE_CACHE = true` / `CFACHE = true`

- Set the max age in the cache-control for the files in S3 to `--cache-control max-age=0,s-maxage=86400`, which will allow CloudFront to cache them.

- Invalidate the CloudFront distribution.


If the app disables caching:

- `ENABLE_CACHE = false` / `CFCACHE = false`

- Set the max age in the cache-control for the files in S3 to `--cache-control private,no-store,no-cache,must-revalidate,max-age=0`, which will prevent CloudFront from ever caching it.

- Do not invalidate the CloudFront distribution because the cache-control on the files renders cache invalidation irrelevant.